### PR TITLE
stop training when specified target reached

### DIFF
--- a/src/deepCam/train_hdf5_ddp.py
+++ b/src/deepCam/train_hdf5_ddp.py
@@ -315,6 +315,7 @@ def main(pargs):
     step = start_step
     epoch = start_epoch
     current_lr = pargs.start_lr if not pargs.lr_schedule else scheduler.get_last_lr()[0]
+    stop_training = False
     net.train()
 
     # start trining
@@ -490,6 +491,7 @@ def main(pargs):
 
                 if (iou_avg_val >= pargs.target_iou):
                     logger.log_event(key = "target_accuracy_reached", value = pargs.target_iou, metadata = {'epoch_num': epoch+1, 'step_num': step})
+                    stop_training = True
 
                 # set to train
                 net.train()
@@ -510,18 +512,22 @@ def main(pargs):
                         checkpoint['amp'] = amp.state_dict()
                     torch.save(checkpoint, os.path.join(output_dir, pargs.model_prefix + "_step_" + str(step) + ".cpt") )
                 logger.log_end(key = "save_stop", metadata = {'epoch_num': epoch+1, 'step_num': step}, sync = True)
+
+            # Stop training?
+            if stop_training:
+                break
             
         # log the epoch
         logger.log_end(key = "epoch_stop", metadata = {'epoch_num': epoch+1, 'step_num': step}, sync = True)
         epoch += 1
         
         # are we done?
-        if epoch >= pargs.max_epochs:
+        if epoch >= pargs.max_epochs or stop_training:
             break
 
     # run done
     logger.log_end(key = "run_stop", sync = True, metadata = {'status' : 'success'})
-    
+
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
@azrael417 ,
It turns out that the results summarizer just checks that at least one eval passes the target quality criteria but computes time as (run_stop - run_start). So, it's important to end training in benchmark runs once the target is reached.

You already have the check in place on the target IOU, but this adds the logic to stop training.

I understand this may not be ideal for all use-cases right now, so I'm open to suggestions about how to configure this. I could add another CL option to enable stopping at target (like `--stop_at_target`), or we could disable the default target value (and hence disable stopping) by default unless the user specifies it.