### PR TITLE
Changes nccl-slurm init to use SLURM_PROCID

### DIFF
--- a/src/deepCam/utils/comm.py
+++ b/src/deepCam/utils/comm.py
@@ -94,7 +94,7 @@ def init(method, batchnorm_group_size=1):
                                 world_size = world_size)
         
     elif method == "nccl-slurm":
-        rank = int(os.getenv("PMIX_RANK"))
+        rank = int(os.getenv("SLURM_PROCID"))
         world_size = int(os.getenv("SLURM_NTASKS"))
         address = os.getenv("SLURM_LAUNCH_NODE_IPADDR")
         port = "29500"


### PR DESCRIPTION
Uses the SLURM_PROCID env variable instead of PMIX_RANK to get rank.

I think this is more appropriate, or at least it's necessary to work properly on our NERSC systems.